### PR TITLE
Update IEC HTML style

### DIFF
--- a/lib/isodoc/iec/html/htmlstyle.scss
+++ b/lib/isodoc/iec/html/htmlstyle.scss
@@ -195,11 +195,11 @@ p.Terms {
 /* Navigation*/
 
 nav {
-    @include sidebarNav(#f7f7f7, 278px, 20px);
+    @include sidebarNav(#f5faff, 278px, 20px);
 }
 
 #toggle {
-    @include sidebarNavToggle(black, #f7f7f7)
+    @include sidebarNavToggle(black, #f5faff)
 }
 
 #toc {
@@ -516,7 +516,7 @@ p.NormRef {
 .figure,
 pre,
 .pseudocode {
-    @include pseudocodeBlock(#f7f7f7);
+    @include pseudocodeBlock(#f5faff);
     font-size: 1em;
 }
 
@@ -667,7 +667,7 @@ ol > li > p:before {
 */
 
 .Quote {
-    @include blockquoteBlock(#f7f7f7);
+    @include blockquoteBlock(#f5faff);
 }
 
 /*
@@ -675,11 +675,11 @@ ol > li > p:before {
 */
 
 .formula {
-    @include formulaBlock(#f7f7f7)
+    @include formulaBlock(#f5faff)
 }
 
 dl.formula_dl {
-background-color: #f7f7f7;
+background-color: #f5faff;
 }
 
 /*

--- a/spec/examples/rice.html
+++ b/spec/examples/rice.html
@@ -269,14 +269,14 @@ p.Terms {
     font-size: 0.9em;
     overflow: auto;
     padding: 0 0 0 20px;
-    background-color: #f7f7f7;
+    background-color: #f5faff;
     line-height: 1.2em; }
   #toggle {
     position: fixed;
     height: 100%;
     width: 30px;
     border-right: solid black 1px;
-    background-color: #f7f7f7;
+    background-color: #f5faff;
     color: black !important;
     cursor: pointer;
     margin-left: -4em;
@@ -506,7 +506,7 @@ p.Biblio, p.NormRef {
   font-variant-ligatures: none; }
 
 .figure, .Sourcecode {
-  background-color: #f7f7f7;
+  background-color: #f5faff;
   line-height: 1.6em;
   padding: 1.5em;
   margin: 2em 0 1em 0;
@@ -639,7 +639,7 @@ ol > li > p:before {
 3.11 Blockquotes
 */
 .blockquote, .Quote {
-  background-color: #f7f7f7;
+  background-color: #f5faff;
   font-style: italic;
   width: 80%;
   padding: 1.5em;
@@ -651,7 +651,7 @@ ol > li > p:before {
 3.12 Formulas
 */
 .formula {
-  background-color: #f7f7f7;
+  background-color: #f5faff;
   padding: 1.5em;
   margin-top: 2em;
   text-align: center;


### PR DESCRIPTION
1. Replace all instances of "Cambria" with "Arial". Beware we don't want to replace "Cambria Math"
2. ~~Replace all instances of "#f7f7f7" with "#f5faff"~~ (this is done)

@w00lf can you take it from here? Thanks.
