### PR TITLE
Remove `sassc` from gem runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,5 @@ source "https://rubygems.org"
 gem 'isodoc',
     git: 'https://github.com/metanorma/isodoc.git',
     branch: 'feature/sassc-gem-dependecey-removal',
-    ref: '536191fb46f9334e749bb56579901d784b25b751'
+    ref: '963c80b0c0c4f223fb461d159fea5a9a2e46be3f'
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,8 @@ Encoding.default_internal = Encoding::UTF_8
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in gemspec
+gem 'isodoc',
+    git: 'https://github.com/metanorma/isodoc.git',
+    branch: 'feature/sassc-gem-dependecey-removal',
+    ref: '536191fb46f9334e749bb56579901d784b25b751'
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,4 @@ Encoding.default_internal = Encoding::UTF_8
 source "https://rubygems.org"
 
 # Specify your gem's dependencies in gemspec
-gem 'isodoc',
-    git: 'https://github.com/metanorma/isodoc.git',
-    branch: 'feature/sassc-gem-dependecey-removal',
-    ref: '963c80b0c0c4f223fb461d159fea5a9a2e46be3f'
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require 'isodoc/gem_tasks'
 
+IsoDoc::GemTasks.install
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec

--- a/metanorma-iec.gemspec
+++ b/metanorma-iec.gemspec
@@ -28,10 +28,11 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
 
   spec.add_dependency "ruby-jing"
-  spec.add_dependency "isodoc", "~> 1.1.0"
+  # spec.add_dependency "isodoc", "~> 1.1.0"
   spec.add_dependency "metanorma-iso", "~> 1.4.0"
 
   spec.add_development_dependency "byebug"
+  spec.add_development_dependency "sassc", "2.4.0"
   spec.add_development_dependency "equivalent-xml", "~> 0.6"
   spec.add_development_dependency "guard", "~> 2.14"
   spec.add_development_dependency "guard-rspec", "~> 4.7"

--- a/metanorma-iec.gemspec
+++ b/metanorma-iec.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
 
   spec.add_dependency "ruby-jing"
-  # spec.add_dependency "isodoc", "~> 1.1.0"
+  spec.add_dependency "isodoc", "~> 1.1.0"
   spec.add_dependency "metanorma-iso", "~> 1.4.0"
 
   spec.add_development_dependency "byebug"


### PR DESCRIPTION
metanorma/metanorma#109 moved sassc gem to dev dependency, temporary added isodoc to Gemfile, added rake build script override.