### PR TITLE
opt out of docid annotation via annotate_docid? predicate: https://github.com/metanorma/metanorma-iso/issues/1236

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,0 +1,2 @@
+gem "isodoc", github: "metanorma/isodoc", branch: "feature/hoist-docid-semantic-annotation"
+gem "metanorma-iso", github: "metanorma/metanorma-iso", branch: "fix/improved-pubid-annotation"

--- a/lib/isodoc/iec/init.rb
+++ b/lib/isodoc/iec/init.rb
@@ -32,8 +32,8 @@ module IsoDoc
         super
       end
 
-      def std_docid_semantic(text)
-        text
+      def annotate_docid?(_id)
+        false
       end
     end
   end


### PR DESCRIPTION
Replace IEC's no-op `def std_docid_semantic(text); text; end` stub in
`lib/isodoc/iec/init.rb` with a predicate `def annotate_docid?(_id); false; end`.

With the semantic-docidentifier-annotation orchestrator hoisted into the
shared `IsoDoc::PresentationXMLConvert` base, the predicate short-circuits
before any annotation runs. Identity behaviour preserved; the toggle point
is now a single predicate that future work can flip to `true` when IEC
wants its own `std_docid_span_classes` override (Pubid::Iec is bundled via
the umbrella `pubid` gem).

`Gemfile.devel` pins both `isodoc` (base hoist) and `metanorma-iso` (ISO
refactor) to their respective PR branches. Both pins are required:
without the metanorma-iso pin IEC inherits ISO's own pre-refactor
`std_docid_semantic` from rubygems and annotation runs against the new
base, producing breakage.

Companion PRs: metanorma/isodoc#795, metanorma/metanorma-iso#1546,
metanorma/metanorma-ieee#741.

Tracking: https://github.com/metanorma/metanorma-iso/issues/1236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
