### PR TITLE
render generator errormsg in related in boldface

### DIFF
--- a/lib/isodoc/iec/presentation_terms.rb
+++ b/lib/isodoc/iec/presentation_terms.rb
@@ -170,8 +170,14 @@ module IsoDoc
         @i18n = @i18n_lg[lg] if lg && @i18n_lg[lg]
         p, ref, orig = related1_prep(node)
         label = @i18n.relatedterms[orig["type"]].upcase
-        node.children = (l10n("<p>#{label}: " \
-                          "#{to_xml(p)} (#{Common::to_xml(ref)})</p>"))
+        err = node.at(ns("./errormsg"))
+        ret = if err
+                # generator-emitted term-resolution failure reports
+                # (metanorma-model-iso#144) render in boldface
+                "<strong>#{to_xml(err.children)}</strong>"
+              else "#{to_xml(p)} (#{Common::to_xml(ref)})"
+              end
+        node.children = (l10n("<p>#{label}: #{ret}</p>"))
         @i18n = @i18n_lg["default"]
       end
 

--- a/spec/isodoc/terms_spec.rb
+++ b/spec/isodoc/terms_spec.rb
@@ -543,4 +543,29 @@ RSpec.describe IsoDoc do
       .sub(%r{</body>.*$}m, "</body>")))
       .to be_html4_equivalent_to word
   end
+
+  it "renders generator errormsg in related in boldface" do
+    input = <<~INPUT
+      <iso-standard xmlns="http://riboseinc.com/isoxml">
+      <sections>
+      <terms id="T" obligation="normative"><title>Terms and definitions</title>
+      <term id="t1"><preferred><expression><name>paddy</name></expression></preferred>
+      <related type="contrast"><errormsg>term <tt>blah</tt> not resolved via ID <tt>blah</tt></errormsg></related>
+      <definition><verbal-definition><p id="d1">rice</p></verbal-definition></definition>
+      </term>
+      </terms>
+      </sections>
+      </iso-standard>
+    INPUT
+    pres_output = IsoDoc::Iec::PresentationXMLConvert
+      .new(presxml_options)
+      .convert("test", input, true)
+    xml = Nokogiri::XML(pres_output)
+    xml.remove_namespaces!
+    fmt = xml.at("//term//strong[tt]")
+    expect(fmt).not_to be_nil
+    expect(fmt.text).to include "not resolved via ID"
+    expect(xml.at("//term/related/errormsg")).not_to be_nil
+    expect(xml.at("//fmt-definition//errormsg")).to be_nil
+  end
 end


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-standoc/pull/1229

Downstream of metanorma-model-iso#144: the `related1` override silently dropped `errormsg` on unresolved related terms; it now renders it boldface, matching base isodoc. Spec added.

🤖
